### PR TITLE
Update git clone command to match repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ There are two different layers in this project. The Node Express backend and the
 
 ## Vue Application
 ### Installation
-1) Clone the repository ``git clone https://github.com/ava-labs/faucet-site.git``
-2) Go to the root directory `cd faucet-site`
+1) Clone the repository ``git clone https://github.com/ava-labs/ava-faucet.git``
+2) Go to the root directory `cd ava-faucet`
 3) Install javascript dependencies with ``npm install``.
 4) Create a ``.env`` file by copying ``.env.example`` 
 5) Install Gecko, our AVA node client written in Golang to spin up a network (https://github.com/ava-labs/gecko). 


### PR DESCRIPTION
Similar to https://github.com/ava-labs/ava-wallet/pull/20 it would be helpful to update the git clone for the ava-faucet to match the current repo's name.